### PR TITLE
fix: 修复执行electron-build过早导致index.html未打包问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,13 @@ export default (api: IApi) => {
 
     regeneratePackageJson(currentMode);
 
-    await buildElectron(api.config.electron.builder || {});
 
     clearTimeout(timer);
   });
+
+  api.onBuildHtmlComplete(async () => {
+    await buildElectron(api.config.electron.builder || {});
+  })
 
   api.modifyConfig({
     fn: (initialValue) => {


### PR DESCRIPTION
修复再umi生成index.html打包导致最终dist/../resouces文件没有index.html。修改为在umi完成index.html生成后，再执行electron-builder。
关联问题：#7 